### PR TITLE
Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Create a new set of connections for your database in database.yml, in the form o
 Create a new directory under db/ called *database_name*_migrate to hold migrations for the database.
 
 ### The Multi Migration command
-Create a new migration with "rails generate multi_migration *migration* *database_name*". The *database_name* is 'default' for your default or original database, otherwise it is the name of the database you wish to migrate to e.g. "rails generate multi_migration AddTitleToWidgets widgets".
+Create a new migration with "rails generate multi_migration *migration* *database_name*". The *database_name* is 'default' for your default or original database (this can also be left off for the default database only and the migration will still work), otherwise it is the name of the database you wish to migrate to e.g. "rails generate multi_migration AddTitleToWidgets widgets".
 
 If you wish to use multi-database-9000 in a single database app, the command 'rails generate migration CreateWidgetsTable' will still work.
 

--- a/features/running_generators.feature
+++ b/features/running_generators.feature
@@ -1,6 +1,7 @@
 Feature: Running rails generate commands produces migration files in the correct database migration folders
   
   'rails generate migration CreateXxxxxTable' should create a migration file in the 'migrate' folder in a single database app
+  'rails generate multi_migration CreateXxxxxTable' should create a migration file in the 'migrate' folder in a multi-database app
   'rails generate multi_migration CreateXxxxxTable default' should create a migration file in the 'migrate' folder in a multi-database app
   'rails generate multi_migration CreateXxxxxTable users' should create a migration file in the 'users_migrate' folder in a multi-database app 
   'rails generate multi_migration CreateXxxxxTable widgets' should create a migration file in the 'widgets_migrate' folder in a multi-database app
@@ -14,10 +15,21 @@ Feature: Running rails generate commands produces migration files in the correct
     Then I should see the db/migrate folder in a single database app
     And I should see a migration file in the db/migrate folder in a single database app
 
+  Scenario: Running 'rails generate migration' in a multi database app
+    Given There are no migration folders before a migration is generated in a multi database app
+    And I run `rails generate migration CreateFoolsTable` in a multi database app
+    Then I should see the db/migrate folder for the default database
+
+  Scenario: Running 'rails generate multi_migration' in a multi database app
+    Given There are no migration folders before a migration is generated in a multi database app
+    And I run `rails generate multi_migration CreateFoolsTable` in a multi database app
+    Then I should see the db/migrate folder for the default database
+
   Scenario: Running "rails generate multi_migration <database_name>" in a multi database app
     Given There are no migration folders before a migration is generated in a multi database app
     And I run `rails generate multi_migration CreateFoolsTable default` in a multi database app
     Then I should see the db/migrate folder for the default database
+
     And I should see a migration file in the db/migrate folder in a multi database app
     And I run `rails generate multi_migration CreateFoolsTable users` in a multi database app
     Then I should see the db/users_migrate folder for the default database

--- a/lib/generators/multi_migration_generator.rb
+++ b/lib/generators/multi_migration_generator.rb
@@ -1,9 +1,9 @@
+
 class MultiMigrationGenerator < Rails::Generators::NamedBase
   include Rails::Generators::Migration
   argument :database_name, :type => :string, :required => false, :banner => 'DBNAME'
   argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
   
-  hook_for :orm, :required => true
   
   source_root File.expand_path('../templates', __FILE__)
   
@@ -35,14 +35,15 @@ class MultiMigrationGenerator < Rails::Generators::NamedBase
   end
   
   protected
-    attr_reader :migration_action
 
-    def set_local_assigns!
-      if file_name =~ /^(add|remove)_.*_(?:to|from)_(.*)/
-        @migration_action = $1
-        @table_name       = $2.pluralize
-      end
+  attr_reader :migration_action
+
+  def set_local_assigns!
+    if file_name =~ /^(add|remove)_.*_(?:to|from)_(.*)/
+      @migration_action = $1
+      @table_name       = $2.pluralize
     end
+  end
 end
 
 

--- a/lib/generators/multi_migration_generator.rb
+++ b/lib/generators/multi_migration_generator.rb
@@ -1,7 +1,6 @@
 class MultiMigrationGenerator < Rails::Generators::NamedBase
   include Rails::Generators::Migration
-  
-  argument :database_name, :type => :string, :required => true, :banner => 'DBNAME'
+  argument :database_name, :type => :string, :required => false, :banner => 'DBNAME'
   argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
   
   hook_for :orm, :required => true
@@ -13,7 +12,7 @@ class MultiMigrationGenerator < Rails::Generators::NamedBase
     if ActiveRecord::Base.timestamped_migrations
       [Time.now.utc.strftime("%Y%m%d%H%M%S"), "%.14d" % next_migration_number].max
     else
-      "%.3d" % next_migration_number
+      SchemaMigration.normalize_migration_number(next_migration_number)
     end
   end
 
@@ -23,11 +22,16 @@ class MultiMigrationGenerator < Rails::Generators::NamedBase
   end
 
   def migration_directory
-    if database_name == "default"
+    if (database_name == "default") || database_is_nil?
       "db/migrate/#{file_name}.rb"
     else
       "db/#{database_name.downcase}_migrate/#{file_name}.rb"
     end
+  end
+
+  def database_is_nil?
+    db_name = database_name
+    return true if db_name.nil?
   end
   
   protected
@@ -40,4 +44,5 @@ class MultiMigrationGenerator < Rails::Generators::NamedBase
       end
     end
 end
+
 

--- a/multi-db-dummy/Gemfile.lock
+++ b/multi-db-dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    multi-database-9000 (0.1.0)
+    multi-database-9000 (0.2.1)
       rails (>= 4.0)
 
 GEM


### PR DESCRIPTION
Removed call to ActiveRecord for running multi_migration generators, as this is unnecessary if we are only generating the migration folder and files. 

Also user can now run a multi_migration without specifying a database and it will go to the default database. This scenario was in the original README. 